### PR TITLE
Added channel browser to ThingSpeak page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_STORE
+.vscode

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Use this simple web-based tool to see data stored in an Internet of Things data 
 * To use Particle - Enter the Access Token for the Particle.io Build Account
 
 ## Features
-* ThingSpeak Data Logger
+* ThingSpeak Data Logger and Channel Browser
 * Particle.io Webhooks Manager
 * Settings are saved in LocalStorage
 * Built using HTML5, Bootstrap, and jQuery

--- a/app/thingspeak.html
+++ b/app/thingspeak.html
@@ -80,11 +80,15 @@
 
             }
 
-            // list channels if user api key is provided
+            // check if a user api key is available
             if (thingspeak['user_api_key']) {
-
-                // find channels
+                // hide user key prompt and load channels
+                $('#user-api-prompt').hide();
                 refreshChannels();
+            }
+            else {
+                // show channel config panel
+                showConfigureChannelPanel();
             }
 
         });
@@ -110,13 +114,30 @@
             thingspeak['user_api_key'] = $('#user_api_key').val();
             thingspeak['tag'] = $('#tag').val();
 
+            // check if user api key is present
             if (thingspeak['user_api_key']) {
-                // refresh channels if user key is present
+
+                // refresh channels
                 refreshChannels();
+
+                // hide prompt to enter key
+                $('#user-api-prompt').hide();
+
+                // hide API key panel
+                hideConfigureChannelPanel();
+
+                // expand channel panel
+                showChannelPanel();
+
             } else {
-                // clear display if user key is not present
+
+                // clear display
                 $('#channels-header').html('');
                 $('#channels').html('');
+
+                // show prompt to enter key
+                $('#user-api-prompt').show();
+
             }
 
             // save to local storage
@@ -320,9 +341,15 @@
                         $('#channel').val(channel.id);
                         $('#read_api_key').val(readKey.api_key);
 
-                        // update configuration and get feed
+                        // update configuration
                         updateFeedParams();
-                        getUpdates();
+
+                        // collapse channels panel
+                        hideChannelPanel();
+
+                        // start fetching updates
+                        play();
+
                     })
 
                     $title.append($title_link);
@@ -351,9 +378,6 @@
 
                 });
 
-                // expand channel panel
-                showChannelPanel();
-
             });
         }
 
@@ -371,7 +395,7 @@
                     $link.css("font-weight","Bold");
                 }
 
-                // add an onClick event that filter's the user's channels by tag
+                // add an onClick event that filters the user's channels by tag
                 $link.click(function ( event ) {
                     event.preventDefault();
 
@@ -403,32 +427,47 @@
 
             // switch button state and start or stop updates
             if ($(button).find(".glyphicon").hasClass("glyphicon-pause")) {
-
-                // show play button state
-                $(button).find(".glyphicon").removeClass("glyphicon-pause").addClass("glyphicon-play");
-
-                // update params
-                thingspeak['start'] = false;
-
-                // stop updates
-                clearInterval(updates);
-
+                pause();
             }
             else {
-
-                // show pause button state
-                $(button).find(".glyphicon").removeClass("glyphicon-play").addClass("glyphicon-pause");
-
-                // update params
-                thingspeak['start'] = true;
-
-                // start updates
-                getUpdates();
-
-                // check for new updates
-                updates = setInterval('getUpdates()',5000);
-
+                play();
             }
+
+        }
+
+        function pause() {
+
+            // show play button state
+            if ($("#start").find(".glyphicon").hasClass("glyphicon-pause")) {
+                $("#start").find(".glyphicon").removeClass("glyphicon-pause").addClass("glyphicon-play");
+            }
+
+            // update params
+            thingspeak['start'] = false;
+
+            // stop updates
+            clearInterval(updates);
+
+            // save to local storage
+            localStorage.setItem('thingspeak', JSON.stringify(thingspeak));
+
+        }
+
+        function play() {
+
+            // show pause button state
+            if ($("#start").find(".glyphicon").hasClass("glyphicon-play")) {
+                $("#start").find(".glyphicon").removeClass("glyphicon-play").addClass("glyphicon-pause");
+            }
+
+            // update params
+            thingspeak['start'] = true;
+
+            // start updates
+            getUpdates();
+
+            // check for new updates
+            updates = setInterval('getUpdates()',5000);
 
             // save to local storage
             localStorage.setItem('thingspeak', JSON.stringify(thingspeak));
@@ -507,7 +546,7 @@
         function toggleChannelPanel(button) {
 
             // switch button state and show/hide panel
-            if ($(button).find(".glyphicon").hasClass("glyphicon-plus")) {
+            if ($(button).find(".glyphicon").hasClass("glyphicon-menu-down")) {
 
                 // call helper show function
                 showChannelPanel();
@@ -524,7 +563,7 @@
         function showChannelPanel() {
 
             // show minus button state
-            $('#toggle-channel-panel').find(".glyphicon").removeClass("glyphicon-plus").addClass("glyphicon-minus");
+            $('#toggle-channel-panel').find(".glyphicon").removeClass("glyphicon-menu-down").addClass("glyphicon-menu-up");
 
             // show panel
             $('#channel-panel').collapse('show');
@@ -534,10 +573,31 @@
         function hideChannelPanel() {
 
             // show plus button state
-            $('#toggle-channel-panel').find(".glyphicon").removeClass("glyphicon-minus").addClass("glyphicon-plus");
+            $('#toggle-channel-panel').find(".glyphicon").removeClass("glyphicon-menu-up").addClass("glyphicon-menu-down");
 
             // hide panel
             $('#channel-panel').collapse('hide');
+
+        }
+
+        function toggleConfigureChannelPanel() {
+
+            // toggle channel panel configuration
+            $('#channel-panel-config').collapse('toggle');
+
+        }
+
+        function showConfigureChannelPanel() {
+
+            // show channel panel configuration
+            $('#channel-panel-config').collapse('show');
+
+        }
+
+        function hideConfigureChannelPanel() {
+
+            // hide channel panel configuration
+            $('#channel-panel-config').collapse('hide');
 
         }
 
@@ -572,25 +632,32 @@
         <div class="panel panel-default">
             <div class="panel-heading">
                 <div class="row">
-                    <div class="col-lg-4">
-                        <div class="input-group">
-                            <span class="input-group-addon">User API Key</span>
-                            <input type="text" class="form-control channel-form" id="user_api_key">
+                    <div class="col-xs-12" style="margin-bottom:10px">
+                        <div class="collapse" id="channel-panel-config">
+                            <div class="input-group">
+                                <span class="input-group-addon">User API Key</span>
+                                <input type="text" class="form-control channel-form" id="user_api_key">
+                            </div>
                         </div>
                     </div>
-                    <div class="col-lg-4">
+
+                    <div class="col-lg-8 col-sm-6">
                         <div class="input-group">
                             <span class="input-group-addon">Tag</span>
                             <input type="search" class="form-control channel-form" id="tag" placeholder="Filter by tag">
                         </div>
                     </div>
-                    <div class="col-lg-4">
+
+                    <div class="col-lg-4 col-sm-6">
                         <button type="button" class="btn btn-primary" onClick="refreshChannels()" id="refresh_channels">
                             <span class="glyphicon glyphicon-refresh"></span>
                         </button>
                         <span style="float:right">
-                            <button type="button" class="btn btn-default" onClick="toggleChannelPanel(this)" id="toggle-channel-panel">
-                                <span class="glyphicon glyphicon-plus"></span>
+                            <button type="button" class="btn btn-default" onClick="toggleConfigureChannelPanel(this)" id="configure-channel-panel">
+                                <span class="glyphicon glyphicon-cog"></span> Configure
+                            </button>
+                            <button type="button" class="btn btn-link" onClick="toggleChannelPanel(this)" id="toggle-channel-panel">
+                                <span class="glyphicon glyphicon-menu-down"></span>
                             </button>
                         </span>
                     </div>
@@ -601,6 +668,12 @@
                 <div class="panel-body">
                     <h3 id="channels-header"></h3>
 
+                    <a href="#" id="user-api-prompt" class="text-muted" onClick="event.preventDefault(); showConfigureChannelPanel();">
+                        <div style="margin:-1em 0 -1em 0" class="well">
+                            <span class="glyphicon glyphicon-info-sign"></span>
+                            Enter a User API Key to browse channels.
+                        </div>
+                    </a>
                     <table class="table table-striped" id="channels"></table>
                 </div>
             </div>

--- a/app/thingspeak.html
+++ b/app/thingspeak.html
@@ -345,6 +345,10 @@
                     $('#channels').append($new_row);
 
                 });
+
+                // expand channel panel
+                showChannelPanel();
+
             });
         }
 
@@ -494,6 +498,44 @@
 
         }
 
+        // toggle for channel info panel
+        function toggleChannelPanel(button) {
+
+            // switch button state and show/hide panel
+            if ($(button).find(".glyphicon").hasClass("glyphicon-plus")) {
+
+                // call helper show function
+                showChannelPanel();
+
+            }
+            else {
+
+                // call helper hide function
+                hideChannelPanel();
+
+            }
+        }
+
+        function showChannelPanel() {
+
+            // show minus button state
+            $('#toggle-channel-panel').find(".glyphicon").removeClass("glyphicon-plus").addClass("glyphicon-minus");
+
+            // show panel
+            $('#channel-panel').collapse('show');
+
+        }
+
+        function hideChannelPanel() {
+
+            // show plus button state
+            $('#toggle-channel-panel').find(".glyphicon").removeClass("glyphicon-minus").addClass("glyphicon-plus");
+
+            // hide panel
+            $('#channel-panel').collapse('hide');
+
+        }
+
       </script>
 </head>
 <body>
@@ -520,6 +562,43 @@
 
         <div class="page-header">
             <h1>ThingSpeak Logger</h1>
+        </div>
+
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <div class="row">
+                    <div class="col-lg-4">
+                        <div class="input-group">
+                            <span class="input-group-addon">User API Key</span>
+                            <input type="text" class="form-control channel-form" id="user_api_key">
+                        </div>
+                    </div>
+                    <div class="col-lg-4">
+                        <div class="input-group">
+                            <span class="input-group-addon">Tag</span>
+                            <input type="search" class="form-control channel-form" id="tag">
+                        </div>
+                    </div>
+                    <div class="col-lg-4">
+                        <button type="button" class="btn btn-primary" onClick="refreshChannels()" id="refresh_channels">
+                            <span class="glyphicon glyphicon-refresh"></span>
+                        </button>
+                        <span style="float:right">
+                            <button type="button" class="btn btn-default" onClick="toggleChannelPanel(this)" id="toggle-channel-panel">
+                                <span class="glyphicon glyphicon-plus"></span>
+                            </button>
+                        </span>
+                    </div>
+                </div>
+            </div>
+
+            <div class="panel-collapse collapse" id="channel-panel">
+                <div class="panel-body">
+                    <h3 id="channels-header"></h3>
+
+                    <table class="table table-striped" id="channels"></table>
+                </div>
+            </div>
         </div>
 
         <div class="panel panel-default">
@@ -559,36 +638,6 @@
                 <table class="table table-striped" id="output"></table>
             </div>
         </div>
-
-        <div class="panel panel-default">
-                <div class="panel-heading">
-                    <div class="row">
-                        <div class="col-lg-4">
-                            <div class="input-group">
-                                <span class="input-group-addon">User API Key</span>
-                                <input type="text" class="form-control channel-form" id="user_api_key">
-                            </div>
-                        </div>
-                        <div class="col-lg-4">
-                            <div class="input-group">
-                                <span class="input-group-addon">Tag</span>
-                                <input type="search" class="form-control channel-form" id="tag">
-                            </div>
-                        </div>
-                        <div class="col-lg-4">
-                            <button type="button" class="btn btn-primary" onClick="refreshChannels()" id="refresh_channels">
-                                <span class="glyphicon glyphicon-refresh"></span>
-                            </button>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="panel-body">
-                    <h3 id="channels-header"></h3>
-
-                    <table class="table table-striped" id="channels"></table>
-                </div>
-            </div>
 
     </div>
 

--- a/app/thingspeak.html
+++ b/app/thingspeak.html
@@ -293,31 +293,21 @@
                     return;
                 }
 
-                // create table head
-                var $table_header = $('<thead></thead>');
-                var $header_row = $('<tr></tr>');
-
-                // add column titles
-                $header_row.append($('<th>Channel Name</th>'));
-                $header_row.append($('<th>ID</th>'));
-                $header_row.append($('<th>Tags</th>'));
-
-                $table_header.append($header_row);
-
-                // add table head
-                $('#channels').append($table_header);
-
                 // add a row for each channel
                 $.each( data, function( i, channel ) {
 
                     // create a new row
-                    var $new_row = $("<tr class='channel-row'></tr>");
+                    var $new_item = $("<li class='list-group-item channel-row'></li>");
+
+                    $new_item.append($('<div class="text-muted" style="float:right">ID: ' + channel.id + '<br />' + (channel.public_flag ? 'Public' : 'Private') + '</div>'))
+
+                    var $title = $('<span></span>');
 
                     // create the channel name link element
-                    var $name_link = $("<a href='#'><b>" + channel.name + "</b></a>");
+                    var $title_link = $('<h4 class="list-group-item-heading"><a href="#">' + channel.name + '</a></h4>');
 
                     // add an onClick event to the name link
-                    $name_link.click(function( event ) {
+                    $title_link.click(function( event ) {
                         // prevent navigation
                         event.preventDefault();
 
@@ -335,25 +325,29 @@
                         getUpdates();
                     })
 
-                    // wrap the name link
-                    var $name_item = $('<td></td>');
-                    $name_item.append($name_link);
+                    $title.append($title_link);
 
                     // add channel name to row
-                    $new_row.append($name_item);
+                    $new_item.append($title);
 
-                    // add channel id to row
-                    $new_row.append("<td>" + channel.id + "</td>");
-
-                    // wrap tag links
-                    var $tag_item = $('<td></td>');
+                    // wrap tag links and add icon
+                    var $tag_item = $('<p class="list-group-item-text"><span class="glyphicon glyphicon-tags" />&nbsp;&nbsp;</p>');
                     $tag_item.append(listTags(channel.tags));
 
+                    // add placeholder if no tags are present
+                    if (channel.tags.length === 0) {
+                        $tag_item.append('<span class="text-muted">None</span>')
+                    }
+
                     // add tag links to row
-                    $new_row.append($tag_item);
+                    $new_item.append($tag_item);
+
+                    if (channel.description && channel.description !== "") {
+                        $new_item.append($('<div class="text-muted">' + channel.description + '</div>'));
+                    }
 
                     // add the row to the table
-                    $('#channels').append($new_row);
+                    $('#channels').append($new_item);
 
                 });
 

--- a/app/thingspeak.html
+++ b/app/thingspeak.html
@@ -276,11 +276,22 @@
 
             $.getJSON( thingspeak['url'] + '/channels.json?api_key=' + thingspeak['user_api_key'] + tagQuery, function( data ) {
 
-                // set channel header including tag if present
-                $('#channels-header').html('Channels' + (thingspeak['tag'] ? ' for Tag: ' + thingspeak['tag'] : ''));
-
                 // clear old channel data
-                $('#channels').html('<table');
+                $('#channels').empty();
+
+                if (data.length > 0) {
+
+                    // set channel header including tag if present
+                    $('#channels-header').html('Channels' + (thingspeak['tag'] ? ' with Tag: ' + thingspeak['tag'] : ''));
+
+                } else {
+
+                    // set channel header including tag if present
+                    $('#channels-header').html('No Channels Found' + (thingspeak['tag'] ? ' with Tag: ' + thingspeak['tag'] : ''));
+
+                    // return so no table is drawn
+                    return;
+                }
 
                 // create table head
                 var $table_header = $('<thead></thead>');
@@ -576,7 +587,7 @@
                     <div class="col-lg-4">
                         <div class="input-group">
                             <span class="input-group-addon">Tag</span>
-                            <input type="search" class="form-control channel-form" id="tag">
+                            <input type="search" class="form-control channel-form" id="tag" placeholder="Filter by tag">
                         </div>
                     </div>
                     <div class="col-lg-4">

--- a/app/thingspeak.html
+++ b/app/thingspeak.html
@@ -632,12 +632,13 @@
         <div class="panel panel-default">
             <div class="panel-heading">
                 <div class="row">
-                    <div class="col-xs-12" style="margin-bottom:10px">
+                    <div class="col-xs-12">
                         <div class="collapse" id="channel-panel-config">
                             <div class="input-group">
                                 <span class="input-group-addon">User API Key</span>
                                 <input type="text" class="form-control channel-form" id="user_api_key">
                             </div>
+                            <div style="height:10px"></div>
                         </div>
                     </div>
 

--- a/app/thingspeak.html
+++ b/app/thingspeak.html
@@ -8,8 +8,9 @@
     <script src="https://cdn.jsdelivr.net/bootstrap/3.3.6/js/bootstrap.min.js"></script>
 
     <style type="text/css">
-      .feed-row { transition: background-color 2s ease; }
-      .rgb-cell { transition: color 0.5s ease, background-color 0.5s ease; }
+        .feed-row { transition: background-color 2s ease; }
+        .rgb-cell { transition: color 0.5s ease, background-color 0.5s ease; }
+        input[type="search"]::-webkit-search-cancel-button { -webkit-appearance: searchfield-cancel-button; }
     </style>
 
     <script type="text/javascript">
@@ -47,6 +48,8 @@
             // set default inputs
             $('#channel').val(thingspeak['channel']);
             $('#read_api_key').val(thingspeak['read_api_key']);
+            $('#user_api_key').val(thingspeak['user_api_key']);
+            $('#tag').val(thingspeak['tag']);
 
             if (thingspeak['location']) {
                 $('#location').find(".glyphicon").removeClass("glyphicon-unchecked").addClass("glyphicon-check");
@@ -60,21 +63,11 @@
                 $('#start').find(".glyphicon").removeClass("glyphicon-play").addClass("glyphicon-pause");
             }
 
-            // when inputs change update params and clear output
-            $( ".form-control" ).change(function(input) {
+            // when feed inputs change update params and clear output
+            $( ".feed-form" ).change(updateFeedParams);
 
-                // update params
-                thingspeak['channel'] = $('#channel').val();
-                thingspeak['read_api_key'] = $('#read_api_key').val();
-
-                // save to local storage
-                localStorage.setItem('thingspeak', JSON.stringify(thingspeak));
-
-                // clear output
-                $('#header').html('');
-                $('#output').html('');
-
-            });
+            // when channel inputs change update params
+            $( ".channel-form" ).change(updateChannelParams);
 
             // start updates if play button is active
             if (thingspeak['start']) {
@@ -87,7 +80,48 @@
 
             }
 
+            // list channels if user api key is provided
+            if (thingspeak['user_api_key']) {
+
+                // find channels
+                refreshChannels();
+            }
+
         });
+
+        function updateFeedParams() {
+
+            // update params
+            thingspeak['channel'] = $('#channel').val();
+            thingspeak['read_api_key'] = $('#read_api_key').val();
+
+            // save to local storage
+            localStorage.setItem('thingspeak', JSON.stringify(thingspeak));
+
+            // clear output
+            $('#header').html('');
+            $('#output').html('');
+
+        }
+
+        function updateChannelParams() {
+
+            // update params
+            thingspeak['user_api_key'] = $('#user_api_key').val();
+            thingspeak['tag'] = $('#tag').val();
+
+            if (thingspeak['user_api_key']) {
+                // refresh channels if user key is present
+                refreshChannels();
+            } else {
+                // clear display if user key is not present
+                $('#channels-header').html('');
+                $('#channels').html('');
+            }
+
+            // save to local storage
+            localStorage.setItem('thingspeak', JSON.stringify(thingspeak));
+        }
 
         function getUpdates() {
 
@@ -199,15 +233,15 @@
 
         function getTableElement(content) {
 
-          // create a table element containing the given content
-          var $td = $('<td>' + content + '</td>');
+            // create a table element containing the given content
+            var $td = $('<td>' + content + '</td>');
 
-          // regex pattern to match RGB hex values
-          // remove preceding ^ to match colors within text
-          var rgbPattern = /^#(([a-f\d]{2}){3})$/i;
+            // regex pattern to match RGB hex values
+            // remove preceding ^ to match colors within text
+            var rgbPattern = /^#(([a-f\d]{2}){3})$/i;
 
-          // check content for a color
-          if (rgbPattern.test(content)) {
+            // check content for a color
+            if (rgbPattern.test(content)) {
 
             // extract that color
             var color = rgbPattern.exec(content)[0];
@@ -223,17 +257,124 @@
 
             // remove background and text color when hovering and restore when mouse exits
             $td.hover(
-              function() {
-                $td.css('background-color', '');
-                $td.css('color', '');
-              },
-              function() {
-                $td.css('background-color', color);
-                $td.css('color', useDarkFont(color) ? '#000' : '#fff');
-              });
-          }
+                function() {
+                    $td.css('background-color', '');
+                    $td.css('color', '');
+                },
+                function() {
+                    $td.css('background-color', color);
+                    $td.css('color', useDarkFont(color) ? '#000' : '#fff');
+                });
+            }
 
-          return $td;
+            return $td;
+        }
+
+
+        function refreshChannels() {
+            var tagQuery = thingspeak['tag'] ? '&tag=' + encodeURIComponent(thingspeak['tag']) : '';
+
+            $.getJSON( thingspeak['url'] + '/channels.json?api_key=' + thingspeak['user_api_key'] + tagQuery, function( data ) {
+
+                // set channel header including tag if present
+                $('#channels-header').html('Channels' + (thingspeak['tag'] ? ' for Tag: ' + thingspeak['tag'] : ''));
+
+                // clear old channel data
+                $('#channels').html('<table');
+
+                // create table head
+                var $table_header = $('<thead></thead>');
+                var $header_row = $('<tr></tr>');
+
+                // add column titles
+                $header_row.append($('<th>Channel Name</th>'));
+                $header_row.append($('<th>ID</th>'));
+                $header_row.append($('<th>Tags</th>'));
+
+                $table_header.append($header_row);
+
+                // add table head
+                $('#channels').append($table_header);
+
+                // add a row for each channel
+                $.each( data, function( i, channel ) {
+
+                    // create a new row
+                    var $new_row = $("<tr class='channel-row'></tr>");
+
+                    // create the channel name link element
+                    var $name_link = $("<a href='#'><b>" + channel.name + "</b></a>");
+
+                    // add an onClick event to the name link
+                    $name_link.click(function( event ) {
+                        // prevent navigation
+                        event.preventDefault();
+
+                        // find channel's read key
+                        var readKey = channel.api_keys.find(function ( key ) {
+                            return key.write_flag;
+                        })
+
+                        // update forms with this channel's id and key
+                        $('#channel').val(channel.id);
+                        $('#read_api_key').val(readKey.api_key);
+
+                        // update configuration and get feed
+                        updateFeedParams();
+                        getUpdates();
+                    })
+
+                    // wrap the name link
+                    var $name_item = $('<td></td>');
+                    $name_item.append($name_link);
+
+                    // add channel name to row
+                    $new_row.append($name_item);
+
+                    // add channel id to row
+                    $new_row.append("<td>" + channel.id + "</td>");
+
+                    // wrap tag links
+                    var $tag_item = $('<td></td>');
+                    $tag_item.append(listTags(channel.tags));
+
+                    // add tag links to row
+                    $new_row.append($tag_item);
+
+                    // add the row to the table
+                    $('#channels').append($new_row);
+
+                });
+            });
+        }
+
+        function listTags(tags) {
+            // create the list container
+            var $list = $('<span></span>');
+
+            // iterate through each tag
+            $.each(tags, function ( i, tag ) {
+                // create a link with the tag's name
+                var $link = $('<a href="#">' + tag.name + '</a>');
+
+                // make the tag bold if it's the currently searched tag
+                if (tag.name.toUpperCase() === thingspeak['tag'].toUpperCase()) {
+                    $link.css("font-weight","Bold");
+                }
+
+                // add an onClick event that filter's the user's channels by tag
+                $link.click(function ( event ) {
+                    event.preventDefault();
+
+                    $('#tag').val(tag.name);
+                    updateChannelParams();
+                });
+
+                // add the tag to the list with a comma if it isn't the last tag
+                $list.append($link).append($('<span>' + (i < tags.length - 1 ? ', ' : '') + '</span>'));
+            })
+
+            return $list;
         }
 
         // tweaked from https://stackoverflow.com/questions/1855884/determine-font-color-based-on-background-color
@@ -387,13 +528,13 @@
                     <div class="col-lg-2">
                         <div class="input-group">
                             <span class="input-group-addon">Channel</span>
-                            <input type="text" class="form-control" id="channel">
+                            <input type="text" class="form-control feed-form" id="channel">
                         </div>
                     </div>
                     <div class="col-lg-4">
                         <div class="input-group">
                             <span class="input-group-addon">Read API Key</span>
-                            <input type="text" class="form-control" id="read_api_key">
+                            <input type="text" class="form-control feed-form" id="read_api_key">
                         </div>
                     </div>
                     <div class="col-lg-6">
@@ -418,6 +559,37 @@
                 <table class="table table-striped" id="output"></table>
             </div>
         </div>
+
+        <div class="panel panel-default">
+                <div class="panel-heading">
+                    <div class="row">
+                        <div class="col-lg-4">
+                            <div class="input-group">
+                                <span class="input-group-addon">User API Key</span>
+                                <input type="text" class="form-control channel-form" id="user_api_key">
+                            </div>
+                        </div>
+                        <div class="col-lg-4">
+                            <div class="input-group">
+                                <span class="input-group-addon">Tag</span>
+                                <input type="search" class="form-control channel-form" id="tag">
+                            </div>
+                        </div>
+                        <div class="col-lg-4">
+                            <button type="button" class="btn btn-primary" onClick="refreshChannels()" id="refresh_channels">
+                                <span class="glyphicon glyphicon-refresh"></span>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="panel-body">
+                    <h3 id="channels-header"></h3>
+
+                    <table class="table table-striped" id="channels"></table>
+                </div>
+            </div>
+
     </div>
 
 </body>

--- a/app/thingspeak.html
+++ b/app/thingspeak.html
@@ -10,6 +10,8 @@
     <style type="text/css">
         .feed-row { transition: background-color 2s ease; }
         .rgb-cell { transition: color 0.5s ease, background-color 0.5s ease; }
+        .glyphicon { vertical-align: text-top; }
+        /* restore webkit search cancel (overridden by Bootstrap) */
         input[type="search"]::-webkit-search-cancel-button { -webkit-appearance: searchfield-cancel-button; }
     </style>
 
@@ -110,6 +112,11 @@
 
         function updateChannelParams() {
 
+            if (!thingspeak['user_api_key'] && $('#user_api_key').val()) {
+                // hide API key panel
+                hideConfigureChannelPanel();
+            }
+
             // update params
             thingspeak['user_api_key'] = $('#user_api_key').val();
             thingspeak['tag'] = $('#tag').val();
@@ -117,14 +124,11 @@
             // check if user api key is present
             if (thingspeak['user_api_key']) {
 
-                // refresh channels
-                refreshChannels();
-
                 // hide prompt to enter key
                 $('#user-api-prompt').hide();
 
-                // hide API key panel
-                hideConfigureChannelPanel();
+                // refresh channels
+                refreshChannels();
 
                 // expand channel panel
                 showChannelPanel();
@@ -137,6 +141,11 @@
 
                 // show prompt to enter key
                 $('#user-api-prompt').show();
+
+                if (thingspeak['tag']) {
+                    // show API key panel
+                    showConfigureChannelPanel();
+                }
 
             }
 
@@ -669,12 +678,12 @@
                 <div class="panel-body">
                     <h3 id="channels-header"></h3>
 
-                    <a href="#" id="user-api-prompt" class="text-muted" onClick="event.preventDefault(); showConfigureChannelPanel();">
-                        <div style="margin:-1em 0 -1em 0" class="well">
-                            <span class="glyphicon glyphicon-info-sign"></span>
-                            Enter a User API Key to browse channels.
-                        </div>
-                    </a>
+                    <div class="well text-muted" id="user-api-prompt" onClick="showConfigureChannelPanel();" style="margin:-1em 0 -1em 0">
+                        <span class="glyphicon glyphicon-info-sign"></span>
+                        <span>Enter a User API Key to browse channels.</span>
+                        <a href="https://thingspeak.com/account/profile" target="_blank">(User API Key?)</a>
+                    </div>
+
                     <table class="table table-striped" id="channels"></table>
                 </div>
             </div>


### PR DESCRIPTION
I've added a channel browser to the top of the ThingSpeak page. The browser takes in a user API key and lists the user's channels. The channels can be filtered by tag and can be selected for logging in the existing interface by clicking on the channel title.